### PR TITLE
Fix vim-rzip no longer being able to open yarn PnP archive files

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/vim-rzip.lua
+++ b/dot_config/nvim/lua/tap/plugins/vim-rzip.lua
@@ -5,23 +5,16 @@ function! DecodeURI(uri)
 endfunction
 
 " Attempt to clear non-focused buffers with matching name
-function! ClearDuplicateBuffers()
-    let uri = bufname()
-
+function! ClearDuplicateBuffers(uri)
     " if our filename has URI encoded characters
-    if DecodeURI(uri) !=# uri
+    if DecodeURI(a:uri) !=# a:uri
         " wipeout buffer with URI decoded name - can print error if buffer in focus
-        sil! exe "bwipeout " . fnameescape(DecodeURI(uri))
+        sil! exe "bwipeout " . fnameescape(DecodeURI(a:uri))
         " change the name of the current buffer to the URI decoded name
-        exe "keepalt file " . fnameescape(DecodeURI(uri))
+        exe "keepalt file " . fnameescape(DecodeURI(a:uri))
         " ensure we don't have any open buffer matching non-URI decoded name
-        sil! exe "bwipeout " . fnameescape(uri)
+        sil! exe "bwipeout " . fnameescape(a:uri)
     endif
-endfunction
-
-function! RzipRead()
-    let uri = bufname()
-    call rzip#Read(DecodeURI(uri), 1)
 endfunction
 
 function! RzipOverride()
@@ -30,15 +23,15 @@ function! RzipOverride()
     exe "au! zip BufReadCmd ".g:zipPlugin_ext
 
     " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
-    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers()
-    autocmd zip BufReadCmd   zipfile:*  call RzipRead()
+    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<afile>"))
+    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
 
     if has("unix")
-        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers()
-        autocmd zip BufReadCmd   zipfile:*/*  call RzipRead()
+        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<afile>"))
+        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
     endif
 
-    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<amatch>')))"
+    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<afile>')))"
 endfunction
 
 autocmd VimEnter * call RzipOverride()

--- a/dot_config/nvim/lua/tap/plugins/vim-rzip.lua
+++ b/dot_config/nvim/lua/tap/plugins/vim-rzip.lua
@@ -5,16 +5,23 @@ function! DecodeURI(uri)
 endfunction
 
 " Attempt to clear non-focused buffers with matching name
-function! ClearDuplicateBuffers(uri)
+function! ClearDuplicateBuffers()
+    let uri = bufname()
+
     " if our filename has URI encoded characters
-    if DecodeURI(a:uri) !=# a:uri
+    if DecodeURI(uri) !=# uri
         " wipeout buffer with URI decoded name - can print error if buffer in focus
-        sil! exe "bwipeout " . fnameescape(DecodeURI(a:uri))
+        sil! exe "bwipeout " . fnameescape(DecodeURI(uri))
         " change the name of the current buffer to the URI decoded name
-        exe "keepalt file " . fnameescape(DecodeURI(a:uri))
+        exe "keepalt file " . fnameescape(DecodeURI(uri))
         " ensure we don't have any open buffer matching non-URI decoded name
-        sil! exe "bwipeout " . fnameescape(a:uri)
+        sil! exe "bwipeout " . fnameescape(uri)
     endif
+endfunction
+
+function! RzipRead()
+    let uri = bufname()
+    call rzip#Read(DecodeURI(uri), 1)
 endfunction
 
 function! RzipOverride()
@@ -23,12 +30,12 @@ function! RzipOverride()
     exe "au! zip BufReadCmd ".g:zipPlugin_ext
 
     " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
-    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<amatch>"))
-    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers()
+    autocmd zip BufReadCmd   zipfile:*  call RzipRead()
 
     if has("unix")
-        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<amatch>"))
-        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers()
+        autocmd zip BufReadCmd   zipfile:*/*  call RzipRead()
     endif
 
     exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<amatch>')))"

--- a/dot_config/nvim/minimal.lua
+++ b/dot_config/nvim/minimal.lua
@@ -11,7 +11,7 @@ local install_path = package_root .. '/packer/start/packer.nvim'
 local function load_plugins()
     require('packer').startup {
         {
-            'wbthomason/packer.nvim', 'lbrayner/vim-rzip'
+            'wbthomason/packer.nvim'
             -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
         },
         config = {
@@ -24,50 +24,6 @@ end
 
 _G.load_config = function()
     -- ADD INIT.LUA SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
-    vim.cmd [[
-" Decode URI encoded characters
-function! DecodeURI(uri)
-    return substitute(a:uri, '%\([a-fA-F0-9][a-fA-F0-9]\)', '\=nr2char("0x" . submatch(1))', "g")
-endfunction
-
-" Attempt to clear non-focused buffers with matching name
-function! ClearDuplicateBuffers(uri)
-echo 'a:uri: '. a:uri
-echo 'expand("<amatch>"): '. expand("<amatch>")
-echo 'expand("<afile>"): '. expand("<afile>")
-echo 'DecodeURI(a:uri): '. DecodeURI(a:uri)
-
-    " if our filename has URI encoded characters
-    if DecodeURI(a:uri) !=# a:uri
-        " wipeout buffer with URI decoded name - can print error if buffer in focus
-        sil! exe "bwipeout " . fnameescape(DecodeURI(a:uri))
-        " change the name of the current buffer to the URI decoded name
-        exe "keepalt file " . fnameescape(DecodeURI(a:uri))
-        " ensure we don't have any open buffer matching non-URI decoded name
-        sil! exe "bwipeout " . fnameescape(a:uri)
-    endif
-endfunction
-
-function! RzipOverride()
-echo "overriding"
-    " Disable vim-rzip's autocommands
-    autocmd! zip BufReadCmd   zipfile:*,zipfile:*/*
-    exe "au! zip BufReadCmd ".g:zipPlugin_ext
-
-    " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
-    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<afile>"))
-    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
-
-    if has("unix")
-        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<afile>"))
-        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
-    endif
-
-    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<afile>')))"
-endfunction
-
-call RzipOverride()
-]]
 end
 
 if vim.fn.isdirectory(install_path) == 0 then

--- a/dot_config/nvim/minimal.lua
+++ b/dot_config/nvim/minimal.lua
@@ -11,7 +11,7 @@ local install_path = package_root .. '/packer/start/packer.nvim'
 local function load_plugins()
     require('packer').startup {
         {
-            'wbthomason/packer.nvim'
+            'wbthomason/packer.nvim', 'lbrayner/vim-rzip'
             -- ADD PLUGINS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
         },
         config = {
@@ -24,6 +24,49 @@ end
 
 _G.load_config = function()
     -- ADD INIT.LUA SETTINGS THAT ARE _NECESSARY_ FOR REPRODUCING THE ISSUE
+    vim.cmd [[
+" Decode URI encoded characters
+function! DecodeURI(uri)
+    return substitute(a:uri, '%\([a-fA-F0-9][a-fA-F0-9]\)', '\=nr2char("0x" . submatch(1))', "g")
+endfunction
+
+" Attempt to clear non-focused buffers with matching name
+function! ClearDuplicateBuffers(uri)
+echo 'a:uri: '. a:uri
+echo 'expand("<amatch>"): '. expand("<amatch>")
+echo 'DecodeURI(a:uri): '. DecodeURI(a:uri)
+
+    " if our filename has URI encoded characters
+    if DecodeURI(a:uri) !=# a:uri
+        " wipeout buffer with URI decoded name - can print error if buffer in focus
+        sil! exe "bwipeout " . fnameescape(DecodeURI(a:uri))
+        " change the name of the current buffer to the URI decoded name
+        exe "keepalt file " . fnameescape(DecodeURI(a:uri))
+        " ensure we don't have any open buffer matching non-URI decoded name
+        sil! exe "bwipeout " . fnameescape(a:uri)
+    endif
+endfunction
+
+function! RzipOverride()
+echo "overriding"
+    " Disable vim-rzip's autocommands
+    autocmd! zip BufReadCmd   zipfile:*,zipfile:*/*
+    exe "au! zip BufReadCmd ".g:zipPlugin_ext
+
+    " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
+    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<amatch>"))
+    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+
+    if has("unix")
+        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<amatch>"))
+        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+    endif
+
+    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<amatch>')))"
+endfunction
+
+call RzipOverride()
+]]
 end
 
 if vim.fn.isdirectory(install_path) == 0 then

--- a/dot_config/nvim/minimal.lua
+++ b/dot_config/nvim/minimal.lua
@@ -34,6 +34,7 @@ endfunction
 function! ClearDuplicateBuffers(uri)
 echo 'a:uri: '. a:uri
 echo 'expand("<amatch>"): '. expand("<amatch>")
+echo 'expand("<afile>"): '. expand("<afile>")
 echo 'DecodeURI(a:uri): '. DecodeURI(a:uri)
 
     " if our filename has URI encoded characters
@@ -54,15 +55,15 @@ echo "overriding"
     exe "au! zip BufReadCmd ".g:zipPlugin_ext
 
     " order is important here, setup name of new buffer correctly then fallback to vim-rzip's handling
-    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<amatch>"))
-    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+    autocmd zip BufReadCmd   zipfile:*  call ClearDuplicateBuffers(expand("<afile>"))
+    autocmd zip BufReadCmd   zipfile:*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
 
     if has("unix")
-        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<amatch>"))
-        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<amatch>")), 1)
+        autocmd zip BufReadCmd   zipfile:*/*  call ClearDuplicateBuffers(expand("<afile>"))
+        autocmd zip BufReadCmd   zipfile:*/*  call rzip#Read(DecodeURI(expand("<afile>")), 1)
     endif
 
-    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<amatch>')))"
+    exe "au zip BufReadCmd ".g:zipPlugin_ext."  call rzip#Browse(DecodeURI(expand('<afile>')))"
 endfunction
 
 call RzipOverride()


### PR DESCRIPTION
Somewhere in the changelog between neovim v0.5.1 and v0.6 the behaviour of `expand('<amatch>')` has changed as it now includes the directory. I guess this happens when the filename isn't absolute but considering URI filenames start with a scheme they don't look absolute, e.g.

```
zipfile:/Users/thomas.payne/git/github.com/yarn-pnp-demo/.yarn/cache/%40testing-library-dom-npm-7.31.2-d66ba6a14d-f930b4797f.zip%3A%3Anode_modules/%40testing-library/dom/types/screen.d.ts
```

The [custom autocmds for vim-rzip](https://github.com/tapayne88/dotfiles/blob/307627340c8206daa7d9591440dc75cde9116368/dot_config/nvim/lua/tap/plugins/vim-rzip.lua) handling is needed to URI decode the above.

The neovim documentation was updated (via a vim-patch) to suggest this change to `<amatch>` expansion but I haven't been able to track down the code change.
https://github.com/vim/vim/commit/4700398e384f38f752b432e187462f404b96847d#diff-4188ca60fe651289f55943772fd6b6b867e721976d75f8be575ecb98ad30e4cbR922-R926

Ultimately to fix it I've swapped to use `<afile>` which seems to be working as before though there was [another attempt](https://github.com/tapayne88/dotfiles/commit/44364032d1616c44c7b40f3a128bddfd75057a1e) that also looked to fix the issue