### PR TITLE
Exclude chezmoi macos files on linux

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,5 +1,12 @@
+# Linux only files
 {{- if eq "macOS" .ostype }}
 .local/share
+{{- end }}
+
+# MacOS only files
+{{- if ne "macOS" .ostype }}
+.Brewfile
+.config/zsh/functions/brew.zsh
 {{- end }}
 
 # Crostini / chrome os patches


### PR DESCRIPTION
#25 introduced some new Homebrew files and these should only be need on MacOS. This updates `.chezmoiignore` to exclude them on linux