### PR TITLE
Improve zsh ssh-agent config

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -77,7 +77,7 @@ export DISABLE_AUTO_TITLE='true'
 
 zstyle :omz:plugins:ssh-agent agent-forwarding on
 zstyle :omz:plugins:ssh-agent identities ""
-zstyle :omz:plugins:ssh-agent lifetime 1h
+zstyle :omz:plugins:ssh-agent lifetime 12h
 
 export ZSH_TMUX_AUTOSTART="true"
 export ZSH_TMUX_AUTOQUIT="false"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -76,7 +76,7 @@ export FPP_DISABLE_SPLIT=1
 export DISABLE_AUTO_TITLE='true'
 
 zstyle :omz:plugins:ssh-agent agent-forwarding on
-zstyle :omz:plugins:ssh-agent identities ""
+zstyle :omz:plugins:ssh-agent lazy true
 zstyle :omz:plugins:ssh-agent lifetime 12h
 
 export ZSH_TMUX_AUTOSTART="true"


### PR DESCRIPTION
Fixes #29 

- Increased ssh-agent identity lifetime
- Replace `identities` with `lazy`