### PR TITLE
Allow `nix-update` to commit flake changes

### DIFF
--- a/dot_config/nvim/lua/tap/lsp/servers/bashls.lua
+++ b/dot_config/nvim/lua/tap/lsp/servers/bashls.lua
@@ -3,7 +3,9 @@ local lsp_utils = require "tap.lsp.utils"
 local module = {}
 
 function module.setup(lsp_server)
-    lsp_server:setup(lsp_utils.merge_with_default_config())
+    lsp_server:setup(lsp_utils.merge_with_default_config {
+        filetypes = {'sh', 'sh.chezmoitmpl'}
+    })
 end
 
 return module

--- a/dot_config/nvim/lua/tap/lsp/servers/diagnosticls.lua
+++ b/dot_config/nvim/lua/tap/lsp/servers/diagnosticls.lua
@@ -39,6 +39,7 @@ local diagnosticls_languages = {
     json = {formatters = {"prettier"}},
     markdown = {linters = {"markdownlint"}, formatters = {"prettier"}},
     sh = {linters = {"shellcheck"}},
+    ['sh.chezmoitmpl'] = {linters = {"shellcheck"}},
     typescript = {linters = {}, formatters = {"prettier"}},
     typescriptreact = {linters = {}, formatters = {"prettier"}}
 }

--- a/dot_local/bin/executable_nix-update.tmpl
+++ b/dot_local/bin/executable_nix-update.tmpl
@@ -16,6 +16,10 @@ Options:
   -v, --verbose   Print script debug info
   --no-color      Suppress color generation
 
+Commands:
+  update          Update all flake inputs to latest (default command when no args)
+  commit          Add and commit flake.lock changes to repo
+
 EOF
   exit
 }
@@ -60,6 +64,8 @@ parse_params() {
     shift
   done
 
+  args=("$@")
+
   return 0
 }
 
@@ -71,16 +77,28 @@ function eval_command {
   eval "$1"
 }
 
-function main {
-  HOME_MANAGER_HOME=$XDG_CONFIG_HOME/nixpkgs
+HOME_MANAGER_HOME=$XDG_CONFIG_HOME/nixpkgs
+FLAKE_LOCKFILE=$HOME_MANAGER_HOME/flake.lock
+CHEZMOI_FLAKE_LOCKFILE=$(chezmoi source-path "$FLAKE_LOCKFILE")
 
+############
+# commands #
+############
+
+function command_commit {
+  if [[ $(command git -C "{{ .chezmoi.sourceDir }}" diff --cached) != $(command git -C "{{ .chezmoi.sourceDir }}" diff --cached "$CHEZMOI_FLAKE_LOCKFILE") ]]; then
+    die "\n${YELLOW}   changes staged in the git repo, please unstage them before continuing${NOFORMAT}\n"
+  fi
+  command git -C "{{ .chezmoi.sourceDir }}" add "$CHEZMOI_FLAKE_LOCKFILE"
+  command git -C "{{ .chezmoi.sourceDir }}" commit --message "Updated flake.lock file"
+}
+
+function command_update {
   eval_command "nix-channel --update"
   eval_command "nix-env -u"
   eval_command "nix flake update $HOME_MANAGER_HOME"
   eval_command "home-manager switch"
 
-  FLAKE_LOCKFILE=$HOME_MANAGER_HOME/flake.lock
-  CHEZMOI_FLAKE_LOCKFILE=$(chezmoi source-path "$FLAKE_LOCKFILE")
   command cp "$FLAKE_LOCKFILE" "$CHEZMOI_FLAKE_LOCKFILE"
   if [[ -n $(command git -C "{{ .chezmoi.sourceDir }}" status --short "$CHEZMOI_FLAKE_LOCKFILE") ]]; then
     msg "\n${YELLOW}   changes made to flake.lock, please commit them${NOFORMAT}\n"
@@ -91,4 +109,10 @@ function main {
   rm -rf "$XDG_CONFIG_HOME/nvim/init.vim"
 }
 
-main
+while :; do
+  case "${args[0]-update}" in
+  commit) command_commit ;;
+  update) command_update ;;
+  esac
+  break
+done

--- a/dot_local/bin/executable_nix-update.tmpl
+++ b/dot_local/bin/executable_nix-update.tmpl
@@ -109,7 +109,7 @@ function command_update {
 
   command cp "$FLAKE_LOCKFILE" "$CHEZMOI_FLAKE_LOCKFILE"
   if [[ -n $(command git -C "{{ .chezmoi.sourceDir }}" status --short "$CHEZMOI_FLAKE_LOCKFILE") ]]; then
-    msg "\n${YELLOW}   changes made to flake.lock, please commit them${NOFORMAT}\n"
+    msg "\n${YELLOW}   changes made to flake.lock, please commit them with \`nix-update commit\`${NOFORMAT}\n"
   fi
 
   # bug with nix neovim config writes init.vim which conflicts with my init.lua
@@ -118,6 +118,7 @@ function command_update {
 }
 
 while :; do
+  # default to update
   case "${args[0]-update}" in
   show) command_show ;;
   commit) command_commit ;;

--- a/dot_local/bin/executable_nix-update.tmpl
+++ b/dot_local/bin/executable_nix-update.tmpl
@@ -68,7 +68,7 @@ setup_colors
 
 function eval_command {
   msg "${BLUE}> $1${NOFORMAT}"
-  eval $1
+  eval "$1"
 }
 
 function main {
@@ -80,15 +80,15 @@ function main {
   eval_command "home-manager switch"
 
   FLAKE_LOCKFILE=$HOME_MANAGER_HOME/flake.lock
-  CHEZMOI_FLAKE_LOCKFILE=$(chezmoi source-path $FLAKE_LOCKFILE)
-  command cp $FLAKE_LOCKFILE $CHEZMOI_FLAKE_LOCKFILE
-  if [[ -n $(command git -C {{ .chezmoi.sourceDir }} status --short $CHEZMOI_FLAKE_LOCKFILE) ]]; then
+  CHEZMOI_FLAKE_LOCKFILE=$(chezmoi source-path "$FLAKE_LOCKFILE")
+  command cp "$FLAKE_LOCKFILE" "$CHEZMOI_FLAKE_LOCKFILE"
+  if [[ -n $(command git -C "{{ .chezmoi.sourceDir }}" status --short "$CHEZMOI_FLAKE_LOCKFILE") ]]; then
     msg "\n${YELLOW}   changes made to flake.lock, please commit them${NOFORMAT}\n"
   fi
 
   # bug with nix neovim config writes init.vim which conflicts with my init.lua
   # https://github.com/nix-community/home-manager/issues/1907
-  rm -rf $XDG_CONFIG_HOME/nvim/init.vim
+  rm -rf "$XDG_CONFIG_HOME/nvim/init.vim"
 }
 
 main

--- a/dot_local/bin/executable_nix-update.tmpl
+++ b/dot_local/bin/executable_nix-update.tmpl
@@ -19,6 +19,7 @@ Options:
 Commands:
   update          Update all flake inputs to latest (default command when no args)
   commit          Add and commit flake.lock changes to repo
+  show            Show last commit that changed flake.lock (reverse chronological commit order)
 
 EOF
   exit
@@ -85,6 +86,13 @@ CHEZMOI_FLAKE_LOCKFILE=$(chezmoi source-path "$FLAKE_LOCKFILE")
 # commands #
 ############
 
+function command_show {
+  # Find last flake.lock commit - no idea why I need to redirect git-log to a
+  # file but head kept exiting non-zero!
+  COMMIT=$(head -n 1 <(command git -C "{{ .chezmoi.sourceDir }}" log --all --oneline "$CHEZMOI_FLAKE_LOCKFILE") | awk '{ print $1 }')
+  command git -C "{{ .chezmoi.sourceDir }}" show "$COMMIT"
+}
+
 function command_commit {
   if [[ $(command git -C "{{ .chezmoi.sourceDir }}" diff --cached) != $(command git -C "{{ .chezmoi.sourceDir }}" diff --cached "$CHEZMOI_FLAKE_LOCKFILE") ]]; then
     die "\n${YELLOW}   changes staged in the git repo, please unstage them before continuing${NOFORMAT}\n"
@@ -111,6 +119,7 @@ function command_update {
 
 while :; do
   case "${args[0]-update}" in
+  show) command_show ;;
   commit) command_commit ;;
   update) command_update ;;
   esac


### PR DESCRIPTION
Added command to make committing changes to the flake lock file easier