### PR TITLE
Improve git config for large repos

### DIFF
--- a/dot_config/nixpkgs/modules/linux.nix
+++ b/dot_config/nixpkgs/modules/linux.nix
@@ -3,7 +3,7 @@
   home.packages = with pkgs; [
     # TODO: Move back to home.nix when no longer at SBG - see flake.nix todo
     openssh
-    git
+    unstable.git
 
     gcc # neovim - building nvim-treesitter parsers
     nq # linux queue utility

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -51,8 +51,7 @@
   manyFiles = true
 
 [alias]
-  st = status -uno
-  stu = status
+  st = status
   cm = commit
   cma = commit --amend
   cmae = commit --amend --no-edit

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -44,6 +44,12 @@
   better-oneline = "format:%C(auto)%h%d %s %Cblue[%cn]"
   summary = "format:%C(yellow)%H%C(red)%d%n%C(blue)%cd %an%n%C(reset)%s%n"
 
+[feature]
+  # Support repos with large number of files, improving git status and git
+  # commit performance. See `man git-config` for details
+  # https://github.com/starship/starship/issues/1617#issuecomment-885959971
+  manyFiles = true
+
 [alias]
   st = status -uno
   stu = status


### PR DESCRIPTION
Found while playing with starship-prompt. Git has added some options for optimising in large repos, they can be enabled using a feature flag in the git config

https://github.com/starship/starship/issues/1617

Took this opportunity to update to unstable nix git and remove previous hacked optimisations that degraded the git experience