### PR TITLE
Fix lsp configuration following breaking nvim-lsp-installer

### DIFF
--- a/dot_config/nvim/lua/tap/lsp/servers/diagnosticls.lua
+++ b/dot_config/nvim/lua/tap/lsp/servers/diagnosticls.lua
@@ -53,7 +53,7 @@ function module.setup(lsp_server)
             init_options = {
                 linters = {
                     markdownlint = {
-                        command = npm.executable(root_dir, "markdownlint"),
+                        command = "markdownlint",
                         isStderr = true,
                         debounce = 100,
                         args = {
@@ -95,8 +95,7 @@ function module.setup(lsp_server)
                                                    "linters"),
                 formatters = {
                     prettier = {
-                        command = prettier_bin or
-                            npm.executable(root_dir, "prettier"),
+                        command = prettier_bin or "prettier",
                         args = {"--stdin-filepath", "%filepath"},
                         rootPatterns = {
                             "package.json", ".prettierrc", ".prettierrc.json",

--- a/dot_config/nvim/lua/tap/lsp/servers/tsserver.lua
+++ b/dot_config/nvim/lua/tap/lsp/servers/tsserver.lua
@@ -1,3 +1,4 @@
+local lspconfig_tsserver = require "lspconfig.server_configurations.tsserver"
 local lsp_utils = require "tap.lsp.utils"
 
 local key_name = function(client_id) return "client_" .. client_id end
@@ -63,7 +64,7 @@ function module.setup(lsp_server)
             end
         },
         cmd = vim.tbl_flatten({
-            default_options.cmd, {"--log-level", "4"},
+            lspconfig_tsserver.default_config.cmd, {"--log-level", "4"},
             {
                 "--tsserver-log-file",
                 vim.env.XDG_CACHE_HOME .. "/nvim/tsserver.log"


### PR DESCRIPTION
A change was made to [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer) (https://github.com/williamboman/nvim-lsp-installer/pull/283) that appropriately sets the environment when starting an lsp server so executables now auto resolve

Unfortunately my config was using the now removed functionality to do something like this so needed updating.