### PR TITLE
Updated references to asdf version to use v0.9.0

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -107,7 +107,7 @@ ${BLUE}rm $NIX_HOME_FILE${NOFORMAT}
 ${BLUE}home-manager switch${NOFORMAT}
 
 # Install asdf https://asdf-vm.com/guide/getting-started.html#_2-download-asdf
-${BLUE}git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.8.1${NOFORMAT}
+${BLUE}git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.9.0${NOFORMAT}
 
 # Install asdf plugins
 # https://github.com/tapayne88/dotfiles/blob/2b7d0baaeba11ef0af5b2f67bbe16ff64c828859/README.md?plain=1#L51-L55

--- a/public/installation_guide.md
+++ b/public/installation_guide.md
@@ -85,7 +85,7 @@ chsh -s `which zsh`
 Installing should just be cloning the repo into `~/.asdf` and installing the plugins ([docs](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf)).
 
 ```bash
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.8.1
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.9.0
 ```
 
 Install the required plugins


### PR DESCRIPTION
There is a new version of asdf, specifically I want https://github.com/asdf-vm/asdf/pull/1033 as it will now error and fail if a `.tool-versions` file requires a plugin that isn't installed