### PR TITLE
Fix for `prepare-commit-msg` not prefixing commit messages with branch reference

### DIFF
--- a/misc/git_template/hooks/prepare-commit-msg
+++ b/misc/git_template/hooks/prepare-commit-msg
@@ -21,7 +21,7 @@ BRANCH_NAME=$(git symbolic-ref --short HEAD 2> /dev/null)
 BRANCH_NAME=$(expr "${BRANCH_NAME##*/}" : '\([a-zA-Z]\{2,\}-[0-9]\{1,\}\)')
 
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
-BRANCH_IN_COMMIT=$(grep -c "$BRANCH_NAME" "$1")
+BRANCH_IN_COMMIT=$(grep -c "^$BRANCH_NAME" "$1")
 
 # Only if
 #  - we have figured out a name


### PR DESCRIPTION
Branches with a ticket reference should prefix commit messages with the branch ref, i.e. on branch `fix/foo-123` the commit messages should have the format
```
foo-123 ...
```

This was failing prefix commits as the branch name does appear in the generated comment of a commit (previously was looking for `[<branch_name>]`). Since removing `[]` need to ensure it only finds names at the start of a line