### PR TITLE
Allow left option to act as alt in kitty on MacOS

### DIFF
--- a/dot_config/kitty/kitty.conf.tmpl
+++ b/dot_config/kitty/kitty.conf.tmpl
@@ -32,6 +32,7 @@ scrollback_pager_history_size       0
 # Disable things like new tabs spawning
 clear_all_shortcuts                 yes
 {{- if eq "macOS" .ostype }}
+macos_option_as_alt		    left
 macos_quit_when_last_window_closed  yes
 macos_show_window_title_in          none
 macos_titlebar_color                background


### PR DESCRIPTION
Preserve right options as is to allow for # / other option characters. This will allow me to use the new keymaps in telescope file_browser

https://github.com/nvim-telescope/telescope-file-browser.nvim/pull/49