### PR TITLE
Swapped powerline git ahead / behind numbers

### DIFF
--- a/dot_p10k.zsh
+++ b/dot_p10k.zsh
@@ -426,11 +426,11 @@
       res+=" ${modified}wip"
     fi
 
-    # ⇣42 if behind the remote.
-    (( VCS_STATUS_COMMITS_BEHIND )) && res+=" ${meta}⇣${VCS_STATUS_COMMITS_BEHIND}"
-    # ⇡42 if ahead of the remote; no leading space if also behind the remote: ⇣42⇡42.
-    (( VCS_STATUS_COMMITS_AHEAD && !VCS_STATUS_COMMITS_BEHIND )) && res+=" "
-    (( VCS_STATUS_COMMITS_AHEAD  )) && res+="${meta}⇡${VCS_STATUS_COMMITS_AHEAD}"
+    # ⇡42 if ahead the remote.
+    (( VCS_STATUS_COMMITS_AHEAD  )) && res+=" ${meta}⇡${VCS_STATUS_COMMITS_AHEAD}"
+    # ⇣42 if behind of the remote; no leading space if also ahead the remote: ⇡42⇣42.
+    (( VCS_STATUS_COMMITS_BEHIND && !VCS_STATUS_COMMITS_AHEAD )) && res+=" "
+    (( VCS_STATUS_COMMITS_BEHIND )) && res+="${meta}⇣${VCS_STATUS_COMMITS_BEHIND}"
     # ⇠42 if behind the push remote.
     (( VCS_STATUS_PUSH_COMMITS_BEHIND )) && res+=" ${meta}⇠${VCS_STATUS_PUSH_COMMITS_BEHIND}"
     (( VCS_STATUS_PUSH_COMMITS_AHEAD && !VCS_STATUS_PUSH_COMMITS_BEHIND )) && res+=" "


### PR DESCRIPTION
Powerline prompt shows the git remote ahead / behind numbers the opposite way round to `git status`.
![Screenshot 2022-01-18 22 35 40](https://user-images.githubusercontent.com/991180/150029744-455451a8-5bbb-4aa5-a54d-13bfe7f5ae14.png)

This should put them the "correct" way round
![Screenshot 2022-01-18 22 33 25](https://user-images.githubusercontent.com/991180/150029823-793fe26e-eff1-4d51-b675-8d1ef19d0f5d.png)
