### PR TITLE
Support nvim-lsp-installer servers with version

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/lspconfig.lua
+++ b/dot_config/nvim/lua/tap/plugins/lspconfig.lua
@@ -44,6 +44,10 @@ local function setup_servers(initialise)
             server:on_ready(function()
                 require("tap.lsp.servers." .. name).setup(server)
             end)
+        else
+            notify("Attempted to setup server " .. server_identifier ..
+                       " with nvim-lsp-installer but not supported", "warn",
+                   {title = "LSPInstall"})
         end
     end
 


### PR DESCRIPTION
[nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer) can install specific versions of servers, this is an update to my loading config to support that.

This also pins lua LS to `2.5.6` to fix #84 