### PR TITLE
Further refining of scripts

### DIFF
--- a/dot_config/nvim/lua/tap/colours.lua
+++ b/dot_config/nvim/lua/tap/colours.lua
@@ -11,7 +11,6 @@ local get_term_theme = function()
 end
 
 local set_colorscheme = function(theme_future, opts)
-    local spawn = opts.spawn == nil and true or false
     -- set nord colorscheme upfront to avoid flickering from "default" scheme
     vim.cmd [[colorscheme nord]]
     return a.run(function()
@@ -19,9 +18,6 @@ local set_colorscheme = function(theme_future, opts)
 
         if (theme == "light") then
             vim.g.use_light_theme = true
-            if spawn == true then
-                vim.loop.spawn("term-theme", {args = {"light"}}, nil)
-            end
 
             vim.o.background = "light"
             require_plugin("tap.plugins.lualine", function(lualine)
@@ -34,9 +30,6 @@ local set_colorscheme = function(theme_future, opts)
             end
         elseif (theme == "dark") then
             vim.g.use_light_theme = false
-            if spawn == true then
-                vim.loop.spawn("term-theme", {args = {"dark"}}, nil)
-            end
 
             vim.g.nord_italic = true
             vim.g.nord_borders = tap.neovim_nightly()
@@ -81,20 +74,18 @@ set_colorscheme(get_term_theme, {announce = false})
 
 command({
     "TermThemeToggle", function()
-        set_colorscheme(function()
+        a.run(function()
             if get_term_theme() == "dark" then
-                return "light"
+                vim.loop.spawn("term-theme", {args = {"light"}}, nil)
             else
-                return "dark"
+                vim.loop.spawn("term-theme", {args = {"dark"}}, nil)
             end
-        end, {announce = true})
+        end)
     end
 })
 command({
     "TermThemeRefresh",
-    function()
-        set_colorscheme(get_term_theme, {announce = true, spawn = false})
-    end
+    function() set_colorscheme(get_term_theme, {announce = true}) end
 })
 
 local change_count = 0
@@ -108,7 +99,7 @@ fwatch.watch(vim.fn.expand("$XDG_CONFIG_HOME") .. "/term_theme", {
         end
 
         vim.schedule(function()
-            set_colorscheme(get_term_theme, {announce = true, spawn = false})
+            set_colorscheme(get_term_theme, {announce = true})
         end)
     end
 })

--- a/dot_config/nvim/lua/tap/colours.lua
+++ b/dot_config/nvim/lua/tap/colours.lua
@@ -9,7 +9,7 @@ local get_term_theme = function()
     return get_os_command_output_async({"term-theme", "echo"}, nil)[1]
 end
 
-local set_colorscheme = function(theme_future)
+local set_colorscheme = function(theme_future, announce)
     -- set nord colorscheme upfront to avoid flickering from "default" scheme
     vim.cmd [[colorscheme nord]]
     return a.run(function()
@@ -24,6 +24,10 @@ local set_colorscheme = function(theme_future)
                 lualine.set_theme('tokyonight')
             end)
             vim.cmd [[colorscheme tokyonight]]
+
+            if announce == true then
+                vim.notify("setting theme to light", "info")
+            end
         elseif (theme == "dark") then
             vim.g.use_light_theme = false
             vim.loop.spawn("term-theme", {args = {"dark"}}, nil)
@@ -35,13 +39,17 @@ local set_colorscheme = function(theme_future)
                 lualine.set_theme('nord_custom')
             end)
             vim.cmd [[colorscheme nord]]
+
+            if announce == true then
+                vim.notify("setting theme to dark", "info")
+            end
         else
             log.error("unknown colorscheme " .. theme)
         end
     end)
 end
 
-set_colorscheme(get_term_theme)
+set_colorscheme(get_term_theme, false)
 
 -- Patch CursorLine highlighting bug in NeoVim
 -- Messes with highlighting of current line in weird ways
@@ -66,14 +74,16 @@ set_colorscheme(get_term_theme)
 -- })
 
 command({
-    "ToggleColor", function()
+    "TermThemeToggle", function()
         set_colorscheme(function()
             if get_term_theme() == "dark" then
                 return "light"
             else
                 return "dark"
             end
-        end)
+        end, true)
     end
 })
-command({"RefreshColor", function() set_colorscheme(get_term_theme) end})
+command({
+    "TermThemeRefresh", function() set_colorscheme(get_term_theme, true) end
+})

--- a/dot_config/nvim/lua/tap/plugins/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/init.lua
@@ -49,6 +49,7 @@ return require('packer').startup(function(use)
     use 'nvim-lua/plenary.nvim'                         -- Utility function used by plugins and my config
     use 'RRethy/vim-illuminate'                         -- Highlight same words
     use 'nathom/filetype.nvim'                          -- A faster version of filetype.vim
+    use 'rktjmp/fwatch.nvim'                            -- Utility for watching files
     -- LuaFormatter on
 
     -- Chunk cache for neovim modules

--- a/dot_local/bin/executable_dkr
+++ b/dot_local/bin/executable_dkr
@@ -23,6 +23,8 @@ Commands:
   exec            Exec into a running container
   run             Run a container image
   logs            Tail running container logs
+  containers      Get container IDs of running containers
+  images          Get image IDs of container images
 
 EOF
   exit
@@ -227,6 +229,24 @@ command_logs() {
   eval "$docker_cmd logs $container ${args[*]:1}"
 }
 
+command_containers() {
+  docker_cmd=$(get_docker_cmd)
+  if [ -z "$docker_cmd" ]; then
+    exit 1
+  fi
+
+  eval "$docker_cmd $ps_cmd" | $(get_fzf_cmd) --multi --header-lines=1 | awk '{ print $1 }'
+}
+
+command_images() {
+  docker_cmd=$(get_docker_cmd)
+  if [ -z "$docker_cmd" ]; then
+    exit 1
+  fi
+
+  eval "$docker_cmd images" | $(get_fzf_cmd) --multi --header-lines=1 | awk '{ print $3 }'
+}
+
 ########
 # Main #
 ########
@@ -240,6 +260,8 @@ while :; do
   exec) command_exec ;;
   run) command_run ;;
   logs) command_logs ;;
+  containers) command_containers ;;
+  images) command_images ;;
   *) die "Unknown command: $1" ;;
   esac
   break

--- a/dot_local/bin/executable_dkr
+++ b/dot_local/bin/executable_dkr
@@ -79,7 +79,9 @@ parse_params() {
 parse_params "$@"
 setup_colors
 
-# helpers
+###########
+# helpers #
+###########
 
 ps_cmd="ps --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}\t{{.Command}}'"
 
@@ -110,7 +112,9 @@ get_fzf_cmd() {
   echo "fzf --height 15"
 }
 
-# commands
+############
+# commands #
+############
 
 command_ps() {
   docker_cmd=$(get_docker_cmd)
@@ -222,6 +226,10 @@ command_logs() {
 
   eval "$docker_cmd logs $container ${args[*]:1}"
 }
+
+########
+# Main #
+########
 
 while :; do
   case "${args[0]}" in

--- a/dot_local/bin/executable_term-theme
+++ b/dot_local/bin/executable_term-theme
@@ -88,7 +88,8 @@ set_kitty_theme() {
 }
 
 set_system_theme() {
-  [ "$1" = "nord" ] && dark-mode on > /dev/null 2>&1 || dark-mode off > /dev/null 2>&1 
+  # return true even if system theme fails so we exit 0
+  [ "$1" = "nord" ] && dark-mode on > /dev/null 2>&1 || dark-mode off > /dev/null 2>&1 || true
 }
 
 read_theme() {

--- a/dot_local/bin/executable_term-theme
+++ b/dot_local/bin/executable_term-theme
@@ -87,6 +87,10 @@ set_kitty_theme() {
   kitty @ --to "$KITTY_LISTEN_ON" set-colors "$XDG_CONFIG_HOME/kitty/colors/$THEME.conf"
 }
 
+set_system_theme() {
+  [ "$1" = "nord" ] && dark-mode on > /dev/null 2>&1 || dark-mode off > /dev/null 2>&1 
+}
+
 read_theme() {
   cat "$THEME_FNAME" 2> /dev/null
 }
@@ -94,7 +98,9 @@ read_theme() {
 parse_params "$@"
 setup_colors
 
-# script logic
+################
+# script logic #
+################
 
 command_echo() {
   THEME=$(read_theme)
@@ -123,6 +129,7 @@ command_toggle() {
 
   echo $THEME > "$THEME_FNAME"
   set_kitty_theme $THEME
+  set_system_theme $THEME
   tmux source-file ~/.tmux.conf
 }
 
@@ -132,6 +139,7 @@ command_light() {
 
   echo $THEME > "$THEME_FNAME"
   set_kitty_theme $THEME
+  set_system_theme $THEME
   tmux source-file ~/.tmux.conf
 }
 
@@ -141,6 +149,7 @@ command_dark() {
 
   echo $THEME > "$THEME_FNAME"
   set_kitty_theme $THEME
+  set_system_theme $THEME
   tmux source-file ~/.tmux.conf
 }
 


### PR DESCRIPTION
- Added some more commands to `dkr`
  - `logs` - allow tailing of container logs via fzf
  - `containers` - handy drop-in for `docker` commands that need a container(s), i.e. `docker restart $(dkr containers)`
  - `images` - like `containers` but for images
- Made `term-theme` toggle macOS dark mode too