### PR TITLE
Add more functionality to `dkr`

### DIFF
--- a/dot_local/bin/executable_dkr
+++ b/dot_local/bin/executable_dkr
@@ -23,6 +23,8 @@ Commands:
   exec            Exec into a running container
   run             Run a container image
   logs            Tail running container logs
+  containers      Get container IDs of running containers
+  images          Get image IDs of container images
 
 EOF
   exit
@@ -227,6 +229,24 @@ command_logs() {
   eval "$docker_cmd logs $container ${args[*]:1}"
 }
 
+command_containers() {
+  docker_cmd=$(get_docker_cmd)
+  if [ -z "$docker_cmd" ]; then
+    exit 1
+  fi
+
+  eval "$docker_cmd $ps_cmd" | $(get_fzf_cmd) --multi --header-lines=1 | awk '{ print $1 }'
+}
+
+command_images() {
+  docker_cmd=$(get_docker_cmd)
+  if [ -z "$docker_cmd" ]; then
+    exit 1
+  fi
+
+  eval "$docker_cmd images" | $(get_fzf_cmd) --multi --header-lines=1 | awk '{ print $3 }'
+}
+
 ########
 # Main #
 ########
@@ -240,6 +260,8 @@ while :; do
   exec) command_exec ;;
   run) command_run ;;
   logs) command_logs ;;
+  containers) command_containers ;;
+  images) command_images ;;
   *) die "Unknown command: $1" ;;
   esac
   break

--- a/dot_local/bin/executable_dkr
+++ b/dot_local/bin/executable_dkr
@@ -79,7 +79,9 @@ parse_params() {
 parse_params "$@"
 setup_colors
 
-# helpers
+###########
+# helpers #
+###########
 
 ps_cmd="ps --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}\t{{.Command}}'"
 
@@ -110,7 +112,9 @@ get_fzf_cmd() {
   echo "fzf --height 15"
 }
 
-# commands
+############
+# commands #
+############
 
 command_ps() {
   docker_cmd=$(get_docker_cmd)
@@ -222,6 +226,10 @@ command_logs() {
 
   eval "$docker_cmd logs $container ${args[*]:1}"
 }
+
+########
+# Main #
+########
 
 while :; do
   case "${args[0]}" in


### PR DESCRIPTION
- `logs` - allow tailing of container logs via fzf
- `containers` - handy drop-in for `docker` commands that need a container(s), i.e. `docker restart $(dkr containers)`
- `images` - like `containers` but for images