### PR TITLE
Fix chezmoi template filetype setting

### DIFF
--- a/dot_config/alacritty/alacritty.yml.tmpl
+++ b/dot_config/alacritty/alacritty.yml.tmpl
@@ -1,3 +1,4 @@
+# vim:ft=yaml
 # Configuration for Alacritty, the GPU enhanced terminal emulator.
 
 # Any items in the `env` entry below will be added as

--- a/dot_config/kitty/kitty.conf.tmpl
+++ b/dot_config/kitty/kitty.conf.tmpl
@@ -1,12 +1,12 @@
 #######
 # env #
 #######
-{{- if eq "crostini" .ostype }}
+#{{- if eq "crostini" .ostype }}
 # Force crostini to use x11 as 'auto' uses 'wayland' which seemingly isn't supported
 # by crostini's compositor (sommelier). Using wayland we get the following error
 # [glfw error 65544]: Wayland: Failed to find xdg-shell in your compositor
 linux_display_server x11
-{{- end }}
+#{{- end }}
 
 ##########
 # Colors #
@@ -31,13 +31,13 @@ scrollback_lines                    0
 scrollback_pager_history_size       0
 # Disable things like new tabs spawning
 clear_all_shortcuts                 yes
-{{- if eq "macOS" .ostype }}
+#{{- if eq "macOS" .ostype }}
 macos_option_as_alt		    left
 macos_quit_when_last_window_closed  yes
 macos_show_window_title_in          none
 macos_titlebar_color                background
 background_opacity                  0.95
-{{- end }}
+#{{- end }}
 
 #####################
 # Keyboard Mappings #

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -13,6 +13,7 @@ require('tap.colours')
 require('tap.auto')
 require('tap.keymap')
 require('tap.jest-nvim')
+require('tap.redir')
 
 vim.cmd [[
 if filereadable(expand('~/.vimrc.local'))

--- a/dot_config/nvim/lua/tap/plugins/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/init.lua
@@ -48,9 +48,28 @@ return require('packer').startup(function(use)
     use 'lervag/file-line'                              -- Handle filenames with line numbers i.e. :20
     use 'nvim-lua/plenary.nvim'                         -- Utility function used by plugins and my config
     use 'RRethy/vim-illuminate'                         -- Highlight same words
-    use 'nathom/filetype.nvim'                          -- A faster version of filetype.vim
     use 'rktjmp/fwatch.nvim'                            -- Utility for watching files
     -- LuaFormatter on
+
+    -- A faster version of filetype.vim
+    use {
+        'nathom/filetype.nvim',
+        config = function()
+            require("filetype").setup({
+                overrides = {
+                    function_extensions = {
+                        ['tmpl'] = function()
+                            local filename = vim.fn.expand("%:t")
+                            local match = filename:match('.*%.(%w+)%.tmpl$')
+                            if match then
+                                vim.bo.filetype = match
+                            end
+                        end
+                    }
+                }
+            })
+        end
+    }
 
     -- Chunk cache for neovim modules
     use {

--- a/dot_config/nvim/lua/tap/plugins/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/init.lua
@@ -52,8 +52,10 @@ return require('packer').startup(function(use)
                         ['tmpl'] = function()
                             local filename = vim.fn.expand("%:t")
                             local match = filename:match('.*%.(%w+)%.tmpl$')
-                            if match then
+                            if match ~= nil then
                                 vim.bo.filetype = match
+                            else
+                                vim.bo.filetype = 'template'
                             end
                         end
                     }

--- a/dot_config/nvim/lua/tap/plugins/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/init.lua
@@ -50,10 +50,15 @@ return require('packer').startup(function(use)
                     function_extensions = {
                         -- Special handling for chezmoi files (templates, etc.)
                         ['tmpl'] = function()
-                            local filename = vim.fn.expand("%:t")
-                            local match = filename:match('.*%.(%w+)%.tmpl$')
-                            if match ~= nil then
-                                vim.bo.filetype = match
+                            local absolute_path = vim.api.nvim_buf_get_name(0)
+                            local is_chezmoi_source_dir =
+                                absolute_path:match('^' ..
+                                                        vim.g.chezmoi_source_dir) ~=
+                                    nil
+                            local ext = absolute_path:match('.*%.(%w+)%.tmpl$')
+
+                            if is_chezmoi_source_dir and ext ~= nil then
+                                vim.bo.filetype = ext
                             else
                                 vim.bo.filetype = 'template'
                             end

--- a/dot_config/nvim/lua/tap/plugins/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/init.lua
@@ -13,19 +13,9 @@ if fn.empty(fn.glob(packer_install_path)) > 0 then
     vim.cmd [[packadd packer.nvim]]
 end
 
--- If chezmoi.vim is available, load immediately
-if fn.empty(fn.glob(packer_scope .. '/opt/chezmoi.vim')) == 0 then
-    vim.g['chezmoi#source_dir_path'] = vim.g.chezmoi_source_dir
-    vim.cmd [[packadd chezmoi.vim]]
-end
-
 return require('packer').startup(function(use)
     -- Packer can manage itself
     use 'wbthomason/packer.nvim'
-
-    -- Special handling for chezmoi files (templates, etc.), set as optional so
-    -- packer doesn't load it,  needs to be loaded earlier than packer can
-    use {'alker0/chezmoi.vim', opt = true}
 
     -- treesitter colorscheme
     use {
@@ -58,6 +48,7 @@ return require('packer').startup(function(use)
             require("filetype").setup({
                 overrides = {
                     function_extensions = {
+                        -- Special handling for chezmoi files (templates, etc.)
                         ['tmpl'] = function()
                             local filename = vim.fn.expand("%:t")
                             local match = filename:match('.*%.(%w+)%.tmpl$')

--- a/dot_config/nvim/lua/tap/redir.lua
+++ b/dot_config/nvim/lua/tap/redir.lua
@@ -1,0 +1,38 @@
+-- Redirect the output of a Vim or external command into a scratch buffer
+-- https://gist.github.com/romainl/eae0a260ab9c135390c30cd370c20cd7
+vim.cmd [[
+function! Redir(cmd, rng, start, end)
+	for win in range(1, winnr('$'))
+		if getwinvar(win, 'scratch')
+			execute win . 'windo close'
+		endif
+	endfor
+
+	if a:cmd =~ '^!'
+		let cmd = a:cmd =~' %'
+			\ ? matchstr(substitute(a:cmd, ' %', ' ' . expand('%:p'), ''), '^!\zs.*')
+			\ : matchstr(a:cmd, '^!\zs.*')
+
+		if a:rng == 0
+			let output = systemlist(cmd)
+		else
+			let joined_lines = join(getline(a:start, a:end), '\n')
+			let cleaned_lines = substitute(shellescape(joined_lines), "'\\\\''", "\\\\'", 'g')
+			let output = systemlist(cmd . " <<< $" . cleaned_lines)
+		endif
+	else
+		redir => output
+		execute a:cmd
+		redir END
+		let output = split(output, "\n")
+	endif
+
+	vnew
+
+	let w:scratch = 1
+	setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile
+	call setline(1, output)
+endfunction
+
+command! -nargs=1 -complete=command -bar -range Redir silent call Redir(<q-args>, <range>, <line1>, <line2>)
+]]

--- a/dot_config/nvim/lua/tap/settings.lua.tmpl
+++ b/dot_config/nvim/lua/tap/settings.lua.tmpl
@@ -79,13 +79,13 @@ end) or {}, " ")
 
 if tap.neovim_nightly() then
     vim.opt.fillchars = {
-      horiz = '━',
-      horizup = '┻',
-      horizdown = '┳',
-      vert = '┃',
-      vertleft  = '┫',
-      vertright = '┣',
-      verthoriz = '╋',
+        horiz = '━',
+        horizup = '┻',
+        horizdown = '┳',
+        vert = '┃',
+        vertleft = '┫',
+        vertright = '┣',
+        verthoriz = '╋'
     }
 end
 

--- a/dot_config/zsh/functions/wsl.zsh.tmpl
+++ b/dot_config/zsh/functions/wsl.zsh.tmpl
@@ -4,7 +4,7 @@ function copy-alacritty-config {
 
 function copy-windows-terminal-config {
   local tmp_wsl_settings="/tmp/windows_terminal_settings.json"
-  cat {{ .chezmoi.sourceDir }}/misc/windows-terminal-settings.json.tmpl | chezmoi execute-template > $tmp_wsl_settings
+  cat "{{ .chezmoi.sourceDir }}/misc/windows-terminal-settings.json.tmpl" | chezmoi execute-template > $tmp_wsl_settings
   fake_chezmoi "$1" $tmp_wsl_settings /mnt/c/Users/tapay/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json
 }
 

--- a/dot_config/zsh/lib/aliases.zsh.tmpl
+++ b/dot_config/zsh/lib/aliases.zsh.tmpl
@@ -1,6 +1,6 @@
-{{- if eq "wsl" .ostype }}
+#{{- if eq "wsl" .ostype }}
 alias open='explorer.exe'
-{{- end }}
+#{{- end }}
 
 # override omz's common-aliases for ls with exa commands
 alias ls='exa --group-directories-first --icons'

--- a/dot_config/zsh/patches/omz.zsh.tmpl
+++ b/dot_config/zsh/patches/omz.zsh.tmpl
@@ -1,6 +1,6 @@
-{{- if eq "macOS" .ostype }}
+#{{- if eq "macOS" .ostype }}
 # Register gls alias to trick oh-my-zsh into thinking we've installed coreutils
 # through homebrew (actually installed with nix). This way we get nice ls color
 # support
 alias gls='ls'
-{{- end }}
+#{{- end }}

--- a/dot_gitconfig-work.tmpl
+++ b/dot_gitconfig-work.tmpl
@@ -1,4 +1,4 @@
-# vim:ft=gitconfig.chezmoitmpl
+# vim:ft=gitconfig
 [user]
   email = {{ .email.work }}
 # {{- if ne "" .github_enterprise_host }}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,3 +1,4 @@
+# vim:ft=gitconfig
 [user]
   name = Tom Payne
   # default to personal email

--- a/dot_tmux.conf.tmpl
+++ b/dot_tmux.conf.tmpl
@@ -1,3 +1,4 @@
+# vim:ft=tmux
 set -g history-limit 10000
 set -g base-index 1
 set -sg escape-time 0

--- a/dot_tmux.conf.tmpl
+++ b/dot_tmux.conf.tmpl
@@ -140,20 +140,20 @@ set -g @1password-items-jq-filter '\
 # fcsonline/tmux-thumbs #
 #########################
 set -g @thumbs-key c-f
-{{- if eq "crostini" .ostype }}
+#{{- if eq "crostini" .ostype }}
 set -g @thumbs-command 'echo -n {} | xsel --clipboard && tmux display-message "Copied {}"'
-{{- end }}
-{{- if eq "macOS" .ostype }}
+#{{- end }}
+#{{- if eq "macOS" .ostype }}
 set -g @thumbs-command 'echo -n {} | pbcopy && tmux display-message "Copied {}"'
-{{- end }}
+#{{- end }}
 set -g @thumbs-upcase-command 'tmux set-buffer {} && tmux paste-buffer'
 
 ##########################
 # tmux-plugins/tmux-yank #
 ##########################
-{{- if eq "crostini" .ostype }}
+#{{- if eq "crostini" .ostype }}
 set -g @override_copy_command 'xsel --clipboard'
-{{- end }}
+#{{- end }}
 set -g @shell_mode 'vi'
 
 # tpm plugins

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -41,13 +41,13 @@ for profile in ''${(z)NIX_PROFILES}; do
   fpath+=($profile/share/zsh/site-functions $profile/share/zsh/$ZSH_VERSION/functions $profile/share/zsh/vendor-completions)
 done
 
-{{- if ne "macOS" .ostype }}
+#{{- if ne "macOS" .ostype }}
 # Fix nix locale errors
 export LOCALE_ARCHIVE=/usr/lib/locale/locale-archive
 export LANGUAGE=en_GB.UTF-8
 export LANG=en_GB.UTF-8
 export LC_ALL=en_GB.UTF-8
-{{- end }}
+#{{- end }}
 
 # Disables scroll lock shortcut (Ctrl+s)
 stty -ixon


### PR DESCRIPTION
A version that fixes filetype setting for `*.tmpl` which was lost when [`filetype.nvim`](https://github.com/nathom/filetype.nvim) was added - seems to conflict with [`chezmoi.vim`](https://github.com/alker0/chezmoi.vim) and can't figure out how to get them to play nice.

Resolves #114 