### PR TITLE
Support formatting without config files

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/lspconfig/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/lspconfig/init.lua
@@ -46,7 +46,12 @@ utils.run {
   -- Setup --
   -----------
   function()
-    require('lsp-format').setup {}
+    require('lsp-format').setup {
+      -- Disabled formatters
+      exclude = {
+        'sumneko_lua', -- use stylua with null-ls for lua
+      },
+    }
     -- Ensure desired servers are installed
     require('mason-lspconfig').setup {
       ensure_installed = servers['mason-lspconfig'],

--- a/dot_config/nvim/lua/tap/plugins/lspconfig/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/lspconfig/init.lua
@@ -50,6 +50,7 @@ utils.run {
       -- Disabled formatters
       exclude = {
         'sumneko_lua', -- use stylua with null-ls for lua
+        'tsserver',
       },
     }
     -- Ensure desired servers are installed

--- a/dot_config/nvim/lua/tap/plugins/lspconfig/servers/null-ls.lua
+++ b/dot_config/nvim/lua/tap/plugins/lspconfig/servers/null-ls.lua
@@ -37,28 +37,9 @@ function M.setup()
       ----------------
       null_ls.builtins.formatting.stylua.with {
         command = path.bin_prefix 'stylua',
-        condition = function(utils)
-          return utils.root_has_file { 'stylua.toml', '.stylua.toml' }
-        end,
       },
       null_ls.builtins.formatting.prettierd.with {
         command = path.bin_prefix 'prettierd',
-        condition = function(utils)
-          return utils.root_has_file {
-            'package.json',
-            '.prettierrc',
-            '.prettierrc.json',
-            '.prettierrc.toml',
-            '.prettierrc.json',
-            '.prettierrc.yml',
-            '.prettierrc.yaml',
-            '.prettierrc.json5',
-            '.prettierrc.js',
-            '.prettierrc.cjs',
-            'prettier.config.js',
-            'prettier.config.cjs',
-          }
-        end,
       },
 
       -----------

--- a/dot_config/nvim/lua/tap/plugins/lspconfig/servers/tsserver.lua
+++ b/dot_config/nvim/lua/tap/plugins/lspconfig/servers/tsserver.lua
@@ -77,23 +77,7 @@ function module.setup()
 
         set_tsc_version(header.client_id, body.payload.version)
       end,
-      ['textDocument/formatting'] = function()
-        -- [lsp-format](https://github.com/lukas-reineke/lsp-format.nvim)
-        -- replaces the default textDocument/formatting handler as part
-        -- of async formatting support.
-        --
-        -- Unfortuantetly despite disabling tsserver formatting it still
-        -- emits these events which messes with the document formatting.
-        --
-        -- Therefore, override tsservers' textDocument/formatting handler
-        -- to not use lsp-format's handler.
-      end,
     },
-    on_attach = function(client, bufnr)
-      -- force tsserver to not format documents
-      client.resolved_capabilities.document_formatting = false
-      lsp_utils.on_attach(client, bufnr)
-    end,
   })
 end
 

--- a/dot_config/nvim/lua/tap/utils/format.lua
+++ b/dot_config/nvim/lua/tap/utils/format.lua
@@ -1,0 +1,90 @@
+local lsp_format = require 'lsp-format'
+local root_pattern = require('tap.utils').root_pattern
+
+local M = {}
+
+-- Used to handle autocommand formatting - Format command (from lsp-format) will
+-- ignore buffer disabling
+local format = function(options)
+  if
+    lsp_format.buffers[options.buf]
+    and lsp_format.buffers[options.buf].should_format
+  then
+    lsp_format.format(options)
+  else
+    vim.notify(
+      'Formatting disabled for buffer due to missing config',
+      vim.log.levels.INFO,
+      { title = 'lsp-format' }
+    )
+  end
+end
+
+local should_format = function()
+  -- TODO: Expand below to use filetype to detect correct root pattern
+  return root_pattern(vim.tbl_flatten {
+    {
+      'package.json',
+      '.prettierrc',
+      '.prettierrc.json',
+      '.prettierrc.toml',
+      '.prettierrc.json',
+      '.prettierrc.yml',
+      '.prettierrc.yaml',
+      '.prettierrc.json5',
+      '.prettierrc.js',
+      '.prettierrc.cjs',
+      'prettier.config.js',
+      'prettier.config.cjs',
+    },
+    { 'stylua.toml', '.stylua.toml' },
+  })(vim.fn.expand '%:p:h') ~= nil
+end
+
+-- Copy of lsp-format's on_attach function to allow overriding of `format` function
+-- https://github.com/lukas-reineke/lsp-format.nvim/blob/b611bd6cea82ccc127cf8fd781a1cb784b0d6d3c/lua/lsp-format/init.lua#L122-L153
+---@param client Client
+---@return nil
+M.lsp_format_on_attach = function(client)
+  if not client.supports_method 'textDocument/formatting' then
+    vim.lsp.log.warn(
+      string.format(
+        '"textDocument/formatting" is not supported for %s, not attaching lsp-format',
+        client.name
+      )
+    )
+    return
+  end
+
+  local bufnr = vim.api.nvim_get_current_buf()
+
+  if lsp_format.buffers[bufnr] == nil then
+    -- Below line has had logic updated to capture if the format config file is present
+    lsp_format.buffers[bufnr] = { should_format = should_format() }
+  end
+
+  table.insert(lsp_format.buffers[bufnr], client.id)
+
+  local format_options = lsp_format.format_options[vim.bo.filetype] or {}
+
+  local event = 'BufWritePost'
+  if format_options.sync then
+    event = 'BufWritePre'
+  end
+
+  local group = vim.api.nvim_create_augroup('Format', { clear = false })
+
+  vim.api.nvim_clear_autocmds {
+    buffer = bufnr,
+    group = group,
+  }
+
+  vim.api.nvim_create_autocmd(event, {
+    group = group,
+    desc = 'format on save',
+    pattern = '<buffer>',
+    callback = format,
+  })
+end
+
+return M

--- a/dot_config/nvim/lua/tap/utils/format.lua
+++ b/dot_config/nvim/lua/tap/utils/format.lua
@@ -2,6 +2,7 @@ local lsp_format = require 'lsp-format'
 local root_pattern = require('tap.utils').root_pattern
 local stylua = require 'null-ls.builtins.formatting.stylua'
 local prettierd = require 'null-ls.builtins.formatting.prettierd'
+local log = require 'plenary.log'
 
 local M = {}
 
@@ -66,13 +67,15 @@ end
 ---@return nil
 M.lsp_format_on_attach = function(client)
   if not client.supports_method 'textDocument/formatting' then
-    vim.lsp.log.warn(
-      string.format(
-        '"textDocument/formatting" is not supported for %s, not attaching lsp-format',
-        client.name
+    if vim.env.LSP_DEBUG then
+      log.warn(
+        string.format(
+          '"textDocument/formatting" is not supported for %s, not attaching lsp-format',
+          client.name
+        )
       )
-    )
-    return
+      return
+    end
   end
 
   local bufnr = vim.api.nvim_get_current_buf()

--- a/dot_config/nvim/lua/tap/utils/lsp.lua
+++ b/dot_config/nvim/lua/tap/utils/lsp.lua
@@ -1,5 +1,6 @@
 local utils = require 'tap.utils'
 local nnoremap = require('tap.utils').nnoremap
+local lsp_format_on_attach = require('tap.utils.format').lsp_format_on_attach
 
 local function toggle_format()
   local filetype = vim.bo.filetype
@@ -29,7 +30,7 @@ local module = {}
 ---@param bufnr number
 ---@return nil
 function module.on_attach(client, bufnr)
-  require('lsp-format').on_attach(client)
+  lsp_format_on_attach(client)
 
   vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
 


### PR DESCRIPTION
Wanted to support formatting files even when there isn't the appropriate configuration file available. They won't format by default but it can be formatted manually with `:Format`.

Might be overkill, could just remove the conditions from null-ls and let everything format 🤷 