### PR TITLE
Add Obsidian note app to crostini

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -12,6 +12,7 @@
 # Crostini / Chrome OS only files
 {{- if ne "crostini" .ostype }}
 .config/zsh/functions/crostini.zsh
+.local/share/applications
 {{- end }}
 
 # WSL only files

--- a/dot_config/nixpkgs/modules/crostini.nix
+++ b/dot_config/nixpkgs/modules/crostini.nix
@@ -5,6 +5,7 @@
     unstable.kitty # kitty terminal
     glxinfo # utility for inspect openGL config
     nixgl.nixGLIntel # OpenGL wrapper for nix programs - Pixelbook specific
+    unstable.obsidian # note taking app
     xsel # copy / paste from neovim
   ];
 }

--- a/dot_local/share/applications/obsidian.desktop.tmpl
+++ b/dot_local/share/applications/obsidian.desktop.tmpl
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Categories=Office
+Comment=Knowledge base
+Exec={{ .chezmoi.homeDir }}/.nix-profile/bin/obsidian %u
+Icon=kitty
+MimeType=x-scheme-handler/obsidian
+Name=Obsidian
+Type=Application
+Version=1.4


### PR DESCRIPTION
Annoyingly had to use the `nixpkgs-unstable` version as I can't figure out how to get unfree software with nixpkgs...