### PR TITLE
Attempt to improve handling of large files

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/telescope.lua
+++ b/dot_config/nvim/lua/tap/plugins/telescope.lua
@@ -188,7 +188,8 @@ return {
       vim.fn.setreg('+', display)
     end
 
-    local new_maker = function(filepath, bufnr, opts)
+    --- Disable treesitter for files that look to be minified
+    local buffer_previewer_maker_custom = function(filepath, bufnr, opts)
       opts = opts or {}
 
       filepath = vim.fn.expand(filepath)
@@ -259,7 +260,7 @@ return {
           results = { '─', '│', '─', '│', '┌', '┐', '┘', '└' },
           preview = { '─', '│', '─', '│', '┌', '┐', '┘', '└' },
         },
-        buffer_previewer_maker = new_maker,
+        buffer_previewer_maker = buffer_previewer_maker_custom,
         preview = {
           timeout = 100,
           -- Need to disable treesitter in config to override default (true)

--- a/dot_config/nvim/lua/tap/plugins/telescope.lua
+++ b/dot_config/nvim/lua/tap/plugins/telescope.lua
@@ -210,15 +210,15 @@ return {
       opts = opts or {}
 
       filepath = vim.fn.expand(filepath)
-      -- require('tap.utils').logger.info(
-      --   'stat',
-      --   filepath,
-      --   stat.size,
-      --   math.floor(stat.size / math.pow(1024, 2)),
-      --   vim.inspect(stat)
-      -- )
 
       check_file_minified(filepath, function(is_file_minified)
+        if is_file_minified then
+          require('tap.utils').logger.info(
+            'disabled treesitter in telescope preview for ',
+            filepath
+          )
+        end
+
         require('telescope.previewers').buffer_previewer_maker(
           filepath,
           bufnr,

--- a/dot_config/nvim/lua/tap/plugins/telescope.lua
+++ b/dot_config/nvim/lua/tap/plugins/telescope.lua
@@ -282,43 +282,6 @@ return {
           -- Need to disable treesitter in config to override default (true)
           -- The custom buffer_previewer_maker will detect when to use it
           treesitter = false,
-          -- filesize_limit = 0,
-          -- 2) Truncate lines to preview window for too large files
-          -- filesize_hook = function(filepath, bufnr, opts)
-          --   local path = require("plenary.path"):new(filepath)
-          --   -- opts exposes winid
-          --   local height = vim.api.nvim_win_get_height(opts.winid)
-          --   local lines = vim.split(path:head(height), "[\r]?\n")
-          --   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-          -- end,
-          -- filesize_hook = function(filepath, bufnr, opts)
-          --   require('tap.utils').logger.info 'here'
-          --   -- local max_bytes = 10000
-          --   -- local cmd = { 'head', '-c', max_bytes, filepath }
-          --   -- require('telescope.previewers.utils').job_maker(cmd, bufnr, opts)
-          --   opts = opts or {}
-
-          --   filepath = vim.fn.expand(filepath)
-          --   vim.loop.fs_stat(filepath, function(_, stat)
-          --     require('tap.utils').logger.info(
-          --       'stat',
-          --       stat.size,
-          --       math.floor(stat.size / math.pow(1024, 2))
-          --     )
-          --     if not stat then
-          --       return
-          --     end
-          --     if stat.size > 100000 then
-          --       return
-          --     else
-          --       require('telescope.previewers').buffer_previewer_maker(
-          --         filepath,
-          --         bufnr,
-          --         opts
-          --       )
-          --     end
-          --   end)
-          -- end,
         },
         path_display = { 'truncate' },
         dynamic_preview_title = true,

--- a/dot_config/nvim/lua/tap/plugins/telescope.lua
+++ b/dot_config/nvim/lua/tap/plugins/telescope.lua
@@ -188,30 +188,13 @@ return {
       vim.fn.setreg('+', display)
     end
 
-    local max_size = math.pow(1024, 2) / 2 -- 500KB
-    local min_file_lines = 10
-    local check_file_minified = function(filepath)
-      local ok, stat = pcall(vim.loop.fs_stat, filepath)
-
-      if not ok or not stat then
-        return false
-      end
-
-      if stat.size > max_size then
-        local path = require('plenary.path'):new(filepath)
-        local lines = vim.split(path:head(min_file_lines), '[\r]?\n')
-        local is_file_minified = lines ~= min_file_lines
-        return is_file_minified
-      end
-      return false
-    end
-
     local new_maker = function(filepath, bufnr, opts)
       opts = opts or {}
 
       filepath = vim.fn.expand(filepath)
 
-      local is_file_minified = check_file_minified(filepath)
+      local is_file_minified =
+        require('tap.utils').check_file_minified(filepath)
 
       if is_file_minified then
         require('tap.utils').logger.info(

--- a/dot_config/nvim/lua/tap/plugins/treesitter.lua
+++ b/dot_config/nvim/lua/tap/plugins/treesitter.lua
@@ -39,7 +39,24 @@ return {
           'vim',
           'yaml',
         },
-        highlight = { enable = true },
+        highlight = {
+          enable = true,
+          disable = function(_, buf)
+            local filepath = vim.api.nvim_buf_get_name(buf)
+
+            local is_file_minified =
+              require('tap.utils').check_file_minified(filepath)
+
+            if is_file_minified then
+              require('tap.utils').logger.info(
+                'disabled treesitter for file ',
+                filepath
+              )
+            end
+
+            return is_file_minified
+          end,
+        },
         matchup = { enable = true },
         playground = {
           enable = true,

--- a/dot_config/nvim/lua/tap/plugins/treesitter.lua
+++ b/dot_config/nvim/lua/tap/plugins/treesitter.lua
@@ -48,6 +48,11 @@ return {
               require('tap.utils').check_file_minified(filepath)
 
             if is_file_minified then
+              vim.notify(
+                'Suspected minified file, disabling treesitter',
+                vim.log.levels.INFO,
+                { title = 'treesitter.nvim' }
+              )
               require('tap.utils').logger.info(
                 'disabled treesitter for file ',
                 filepath

--- a/dot_config/nvim/lua/tap/utils/init.lua
+++ b/dot_config/nvim/lua/tap/utils/init.lua
@@ -1,4 +1,39 @@
+local log = require 'plenary.log'
+
 local M = {}
+
+---Detect if environment variable is set and is truthy
+---@param env_var string
+---@return boolean
+function M.getenv_bool(env_var)
+  local value = vim.fn.getenv(env_var)
+  if value == vim.NIL then
+    return false
+  end
+
+  return vim.tbl_contains({ 'true', '1' }, value:lower())
+end
+
+-- Setup logger
+local plugin = 'tap-lua'
+local DEBUG = M.getenv_bool 'DEBUG'
+
+vim.schedule(function()
+  if DEBUG then
+    vim.notify(
+      string.format(
+        '%s/%s.log',
+        vim.api.nvim_call_function('stdpath', { 'cache' }),
+        plugin
+      )
+    )
+  end
+end)
+
+M.logger = log.new {
+  plugin = plugin,
+  level = DEBUG and 'debug' or 'info',
+}
 
 ---@module 'tap.utils.lsp'
 

--- a/dot_config/nvim/lua/tap/utils/init.lua
+++ b/dot_config/nvim/lua/tap/utils/init.lua
@@ -32,7 +32,7 @@ end)
 
 M.logger = log.new {
   plugin = plugin,
-  level = DEBUG and 'debug' or 'info',
+  level = DEBUG and 'debug' or 'warn',
 }
 
 ---@module 'tap.utils.lsp'

--- a/dot_config/nvim/lua/tap/utils/init.lua
+++ b/dot_config/nvim/lua/tap/utils/init.lua
@@ -415,4 +415,25 @@ function M.root_pattern(patterns)
   return find_root
 end
 
+local max_size = math.pow(1024, 2) / 2 -- 500KB
+local min_file_lines = 10
+---Determine if file looks to be minifed. Criteria is a large file with few lines
+---@param filepath string
+---@return boolean
+function M.check_file_minified(filepath)
+  local ok, stat = pcall(vim.loop.fs_stat, filepath)
+
+  if not ok or not stat then
+    return false
+  end
+
+  if stat.size > max_size then
+    local path = require('plenary.path'):new(filepath)
+    local lines = vim.split(path:head(min_file_lines), '[\r]?\n')
+    local is_file_minified = lines ~= min_file_lines
+    return is_file_minified
+  end
+  return false
+end
+
 return M

--- a/dot_config/nvim/lua/tap/utils/lsp.lua
+++ b/dot_config/nvim/lua/tap/utils/lsp.lua
@@ -221,12 +221,7 @@ end
 --- Check if we're running in LSP debug mode
 ---@return boolean
 function M.lsp_debug_enabled()
-  local lspDebug = vim.env.LSP_DEBUG
-  if lspDebug == nil then
-    return false
-  end
-
-  return vim.tbl_contains({ 'true', '1' }, lspDebug:lower())
+  return require('tap.utils').getenv_bool 'LSP_DEBUG'
 end
 
 return M


### PR DESCRIPTION
- Attempts to detect minified files, these tend to be large file size over few lines
- Disable treesitter previews in telescope for minified files
- Disable treesitter syntax highlighting for minified files
- Also added a logger to help diagnose config issues