### PR TITLE
Added session saving and restoration

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/editor.lua
+++ b/dot_config/nvim/lua/tap/plugins/editor.lua
@@ -473,7 +473,12 @@ return {
           events = { 'FileType' },
           targets = { 'gitcommit' },
           command = function()
-            require('persistence').stop()
+            -- If there is only one buffer open then it's probably a commit
+            -- message instance (which we don't want to save as the directories
+            -- session)
+            if #vim.api.nvim_list_bufs() == 1 then
+              require('persistence').stop()
+            end
           end,
         },
       })

--- a/dot_config/nvim/lua/tap/plugins/editor.lua
+++ b/dot_config/nvim/lua/tap/plugins/editor.lua
@@ -462,4 +462,23 @@ return {
       )
     end,
   },
+
+  {
+    'folke/persistence.nvim',
+    event = 'BufReadPre', -- this will only start session saving when an actual file was opened
+    config = function()
+      -- Prevent Persistence from saving a session for commit messages
+      require('tap.utils').augroup('TapPersistence', {
+        {
+          events = { 'FileType' },
+          targets = { 'gitcommit' },
+          command = function()
+            require('persistence').stop()
+          end,
+        },
+      })
+
+      require('persistence').setup()
+    end,
+  },
 }

--- a/dot_config/nvim/lua/tap/plugins/ui.lua
+++ b/dot_config/nvim/lua/tap/plugins/ui.lua
@@ -185,6 +185,11 @@ return {
 
       dashboard.section.buttons.val = {
         dashboard.button(
+          'p',
+          ' ' .. ' Restore last session',
+          ':lua require("persistence").load()<CR>'
+        ),
+        dashboard.button(
           'r',
           ' ' .. ' Recent files',
           ':lua require("telescope.builtin").oldfiles{ cwd_only = true }<CR>'


### PR DESCRIPTION
- Saves session per directory
- Adds restoration button on new instance dashboard
- Avoid saving session for commit messages & other transient neovim instances