### PR TITLE
Update own mason registry to work with new config

### DIFF
--- a/dot_config/nvim/lua/tap/plugins/coding.lua
+++ b/dot_config/nvim/lua/tap/plugins/coding.lua
@@ -142,7 +142,7 @@ return {
   -- The interactive scratchpad for hackers
   {
     'metakirby5/codi.vim',
-    config = function()
+    init = function()
       require('tap.utils.lsp').ensure_installed {
         'tsun',
       }

--- a/dot_config/nvim/lua/tap/plugins/mason/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/mason/init.lua
@@ -6,8 +6,11 @@ return {
     'williamboman/mason-lspconfig.nvim',
   },
   config = function()
-    require('mason').setup()
-
-    require 'tap.plugins.mason.registry'
+    require('mason').setup {
+      registries = {
+        'github:mason-org/mason-registry',
+        'lua:tap.plugins.mason.registry',
+      },
+    }
   end,
 }

--- a/dot_config/nvim/lua/tap/plugins/mason/registry/init.lua
+++ b/dot_config/nvim/lua/tap/plugins/mason/registry/init.lua
@@ -1,3 +1,3 @@
-local index = require 'mason-registry.index'
-
-index['tsun'] = 'tap.plugins.mason.registry.tsun'
+return {
+  tsun = 'tap.plugins.mason.registry.tsun',
+}


### PR DESCRIPTION
Use new registry config to load local lua registry files. Following the announcement of the new mason-registry this may be required later on to avoid errors

https://www.reddit.com/r/neovim/comments/122ow0u/psa_changes_to_the_masonnvim_registry/

This approach is also a bit nicer that the hacky patching of the previous approach